### PR TITLE
Makefile/minor changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # XDG_DATA_HOME
 # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-DATA=$(if $(XDG_DATA_HOME),$(XDG_DATA_HOME)/testdata/wsi,$(HOME)/.local/share/testdata/wsi)
+DATA_ROOT=$(or $(XDG_DATA_HOME),$(HOME)/.local/share)
+WSI_ROOT=$(DATA_ROOT)/testdata/wsi
 
-download: $(DATA)
+WSI_LIST=CMU-1.svs CMU-2.svs CMU-3.svs
+
+download: $(foreach file,$(WSI_LIST),$(WSI_ROOT)/$(file))
 
 URL=https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio
-$(DATA):
-	mkdir -p $@
-	@cd $@; $(foreach file,CMU-1.svs CMU-2.svs CMU-3.svs,curl -O $(URL)/$(file);)
+$(WSI_ROOT)/%:
+	@mkdir -p $(@D)
+	curl $(URL)/$* -o $@

--- a/helloworld/Makefile
+++ b/helloworld/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile
+
 IMAGE=helloworld
 
 # this uses the host pip configuration when available for building the docker image
@@ -14,16 +16,15 @@ image-test:
 	@docker build $(PIP) --target test -t $(IMAGE_TEST) .
 
 test: image-test
-	@docker run -ti --rm -v $(WSI):/wsi:ro $(IMAGE_TEST) \
+	@docker run --rm -v $(WSI_ROOT):/wsi:ro $(IMAGE_TEST) \
 		pytest -s
 
 lint: image-test
-	@docker run -ti --rm $(IMAGE_TEST) \
+	@docker run --rm $(IMAGE_TEST) \
 		ruff check
 
 # this runs the docker container to produce test results
 UID=$(shell id -u)
-WSI=$(PWD)/../data/wsi
 gold: image-main
-	@docker run -ti --rm -v $(WSI):/wsi:ro -v $(PWD):/out -w /out -u $(UID):$(UID) $(IMAGE_MAIN) \
+	@docker run --rm -v $(WSI_ROOT):/wsi:ro -v $(PWD):/out -w /out -u $(UID):$(UID) $(IMAGE_MAIN) \
 		bash -c "cat tests/data/samples.jsonl | python3 /src/main.py"


### PR DESCRIPTION
Minor changes to the Makefiles
* `helloworld` `Makefile` was not using the same location for slides
  * base `Makefile` splits `DATA_ROOT` from `WSI_ROOT` variables (presumably there could be more data than only WSI)
  * `helloworld` `Makefile` can use `WSI_ROOT` as it is now including the base `Makefile`

Extra changes
* base `Makefile` now has a per-wsi target to download slides independantly
  * existence of the `DATA` directory was enough to never download again even if slides would have been added to the list
* removed the `-ti` from the `docker` invocations in the `helloworld` `Makefile` - those are not necessary to run the commands as stdin is not used and there is no need for interaction

*NOTES*
* There is no flexibility as to the source of the WSIs - they're only Aperio from the openslide test data